### PR TITLE
Get language attribute directly from Stanza pipeline object

### DIFF
--- a/spacy_stanza/language.py
+++ b/spacy_stanza/language.py
@@ -27,7 +27,11 @@ class StanzaLanguage(Language):
         kwargs: Optional config parameters.
         RETURNS (spacy.language.Language): The nlp object.
         """
-        lang = snlp.processors["tokenize"].config["lang"]  # TODO: is this right?
+        if hasattr(snlp, 'lang'):
+            lang = snlp.lang
+        else:
+            # backward compatible with stanza v1.0.0
+            lang = snlp.processors["tokenize"].config["lang"]
         self.snlp = snlp
         self.svecs = StanzaLanguage._find_embeddings(snlp)
         self.lang = "stanza_" + lang


### PR DESCRIPTION
Starting from Stanza v1.0.1, `lang` has been an attribute of the pipeline object: https://github.com/stanfordnlp/stanza/blob/82afe7fbfe51f30c878959f65909a6cc64ee14ab/stanza/pipeline/core.py#L68

This PR adapts the spacy-stanza pipeline initialization to this change, while maintaining some backward compatibility with Stanza v1.0.0.