### PR TITLE
Don't restrict minor version of stanza

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def setup_package():
         version=about["__version__"],
         license=about["__license__"],
         packages=find_packages(),
-        install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0,<1.3.0"],
+        install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0,<2.0.0"],
         python_requires=">=3.6",
         entry_points={
             "spacy_tokenizers": [


### PR DESCRIPTION
Usually minor versions should not contain breaking changes so it should be fine to have this to <2.0 for now.

Restricting to <1.3.0 makes spacy-stanza incompatible with current dev branch of stanza. (I incorrectly mention in the commit incompatibility with stanza's master, but that is incorrect (which is at 1.2.1). `dev` is at 1.3.0)