### PR TITLE
Fallback to upos instead of to feats

### DIFF
--- a/spacy_stanza/tokenizer.py
+++ b/spacy_stanza/tokenizer.py
@@ -143,7 +143,7 @@ class StanzaTokenizer(object):
                 assert word == token.text
 
                 pos.append(token.upos or "")
-                tags.append(token.xpos or token.feats or "")
+                tags.append(token.xpos or token.upos or "")
                 morphs.append(token.feats or "")
                 deps.append(token.deprel or "")
                 heads.append(snlp_heads[i + offset])

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -215,5 +215,3 @@ def test_spacy_stanza_from_config():
     nlp = English.from_config(config)
     assert nlp.Defaults == EnglishDefaults
     assert type(nlp.tokenizer) == spacy_stanza.tokenizer.StanzaTokenizer
-
-# pytest tests -k spacy_stanza_spanish

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,5 +1,7 @@
 from spacy.lang.en import EnglishDefaults, English
 from spacy.lang.de import GermanDefaults
+from spacy.lang.es import SpanishDefaults
+
 import spacy_stanza
 import stanza
 import pytest
@@ -116,6 +118,19 @@ def test_spacy_stanza_german():
     # warning for misaligned ents due to multi-word token expansion
     with pytest.warns(UserWarning):
         doc = nlp("Auf dem Friedhof an der Straße Am Rosengarten")
+
+
+def test_spacy_stanza_spanish():
+    lang = "es"
+    stanza.download(lang)
+    nlp = spacy_stanza.load_pipeline(lang)
+    assert nlp.Defaults == SpanishDefaults
+
+    doc = nlp("No puedo creer lo aburrida que está esta clase.")
+
+    # The Spanish models do not have xpos (tag_) (token.xpos is None)
+    # As a fallback, tag_ should be the same as pos_
+    assert [t.pos_ for t in doc] == [t.tag_ for t in doc] == ['ADV', 'AUX', 'VERB', 'PRON', 'ADJ', 'PRON', 'VERB', 'DET', 'NOUN', 'PUNCT']
 
 
 def test_spacy_stanza_tokenizer_options():

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -138,12 +138,35 @@ def test_spacy_stanza_spanish():
     # UDv2.9 does have xpos tags. So to make sure this test runs successfully, only
     # run it when we know that the original stanza xpos is None (UD<v2.9)
     if all(w.xpos is None for sent in sdoc.sentences for w in sent.words):
-        assert [t.pos_ for t in doc] == [t.tag_ for t in doc] == ["DET", "NOUN", "ADP", "NOUN", "PRON", "VERB", "ADP",
-                                                                  "NOUN", "ADP", "NUM", "NOUN", "ADJ", "ADP", "DET",
-                                                                  "NOUN", "NOUN", "ADP", "NOUN", "PUNCT"]
+        assert (
+            [t.pos_ for t in doc]
+            == [t.tag_ for t in doc]
+            == [
+                "DET",
+                "NOUN",
+                "ADP",
+                "NOUN",
+                "PRON",
+                "VERB",
+                "ADP",
+                "NOUN",
+                "ADP",
+                "NUM",
+                "NOUN",
+                "ADJ",
+                "ADP",
+                "DET",
+                "NOUN",
+                "NOUN",
+                "ADP",
+                "NOUN",
+                "PUNCT",
+            ]
+        )
     else:
         # TODO: update here when new models use UDv2.9 xpos labels
         pass
+
 
 def test_spacy_stanza_tokenizer_options():
     # whitespace tokens from spacy tokenizer are handled correctly

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -126,11 +126,13 @@ def test_spacy_stanza_spanish():
     nlp = spacy_stanza.load_pipeline(lang)
     assert nlp.Defaults == SpanishDefaults
 
-    doc = nlp("No puedo creer lo aburrida que está esta clase.")
+    # Example from the training data so that labels are likely correct
+    # https://github.com/UniversalDependencies/UD_Spanish-AnCora
+    doc = nlp("Las reservas en oro se valoran en base a 300 dólares estadounidenses por cada onza troy de oro.")
 
     # The Spanish models do not have xpos (tag_) (token.xpos is None)
     # As a fallback, tag_ should be the same as pos_
-    assert [t.pos_ for t in doc] == [t.tag_ for t in doc] == ['ADV', 'AUX', 'VERB', 'PRON', 'ADJ', 'PRON', 'VERB', 'DET', 'NOUN', 'PUNCT']
+    assert [t.pos_ for t in doc] == [t.tag_ for t in doc] == ["DET", "NOUN", "ADP", "NOUN", "PRON", "VERB", "ADP", "NOUN", "ADP", "NUM", "NOUN", "ADJ", "ADP", "DET", "NOUN", "NOUN", "ADP", "NOUN", "PUNCT"]
 
 
 def test_spacy_stanza_tokenizer_options():


### PR DESCRIPTION
This PR makes sure that the fallback for `tag_` in spacy-stanza is the same as in spaCy. Currently this is dealt with differently in `spacy-stanza` compared to spaCy. In spaCy, the attributeruler copies `pos` to `tag` in case `tag` is not defined. However, in spacy_stanza, the morphological features are used instead. That is not desirable, I think. As a user you would expect the same behavior in spaCy and spacy_stanza.

More info and examples in the linked issue https://github.com/explosion/spacy-stanza/issues/76

For reference, `spacy-udpipe` [does not have a fallback](https://github.com/TakeLab/spacy-udpipe/blob/a38cd1e1c8dc5e18def177cd21d12922da833d6f/spacy_udpipe/tokenizer.py#L115), although if you agree with the current PR I may ask TakeLab whether they want to streamline their behavior as well.

**Warning**: this PR _does_ result in a breaking change, potentially resulting in different Token.tag_ values than before

Added a test for Spanish to illustrate the issue, which currently does not have xpos.

closes #76 