### PR TITLE
Add project urls to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,10 @@ def setup_package():
             "Programming Language :: Python :: 3.10",
         ],
         zip_safe=False,
+        project_urls={
+            "Release notes": "https://github.com/explosion/spacy-stanza/releases",
+            "Source": "https://github.com/explosion/spacy-stanza",
+        },
     )
 
 


### PR DESCRIPTION
This adds the links to PyPI. To see that in action check out https://pypi.org/project/spacy/ (source code: https://github.com/explosion/spaCy/pull/7728, but for declarative packaging config)