### PR TITLE
Add support for stanza 1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 spacy>=3.0.0,<4.0.0
-stanza>=1.2.0,<1.6.0
+stanza>=1.2.0,<1.7.0
 # Development dependencies
 pytest>=5.2.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ def setup_package():
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
         ],
         zip_safe=False,
     )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def setup_package():
         version=about["__version__"],
         license=about["__license__"],
         packages=find_packages(),
-        install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0,<1.6.0"],
+        install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0,<1.7.0"],
         python_requires=">=3.6",
         entry_points={
             "spacy_tokenizers": [
@@ -48,6 +48,7 @@ def setup_package():
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
         ],
         zip_safe=False,
     )


### PR DESCRIPTION
Also both spaCy and stanza (as of 1.6.1) officially support Python 3.11, therefore I don't see a reason why spacy-stanza shouldn't.  Tests passed on my machine with Python 3.11.  (Also we're running spacy-stanza for a while now with Python 3.11 on production and haven't noticed any issues.)