### PR TITLE
CI: Use latest actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure Python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64


### PR DESCRIPTION
Fixes:

    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20:
    actions/checkout@v3, actions/setup-python@v4. For more information see:
    https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The test failures are unrelated.  See explosion/spacy-stanza#102 for more details and explosion/spacy-stanza#101 for a “fix”.