### PR TITLE
Drop support for Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python_version: ["3.7", "3.11"]
+        python_version: ["3.8", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def setup_package():
         license=about["__license__"],
         packages=find_packages(),
         install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0,<1.7.0"],
-        python_requires=">=3.6",
+        python_requires=">=3.8",
         entry_points={
             "spacy_tokenizers": [
                 "spacy_stanza.PipelineAsTokenizer.v1 = spacy_stanza:tokenizer.create_tokenizer",
@@ -43,8 +43,6 @@ def setup_package():
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
-            "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Python 3.6 reached its [EOL on 2021-12-23](https://peps.python.org/pep-0494/#lifespan) (~2.5 years ago) and Python 3.7 reached its [EOL on 2023-06-27](https://peps.python.org/pep-0537/#lifespan) (almost 1 year ago)