### PR TITLE
Add support for stanza 1.7 and 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 spacy>=3.0.0,<4.0.0
-stanza>=1.2.0,<1.7.0
+stanza>=1.2.0,<1.9.0
 # Development dependencies
 pytest>=5.2.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def setup_package():
         version=about["__version__"],
         license=about["__license__"],
         packages=find_packages(),
-        install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0,<1.7.0"],
+        install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0,<1.9.0"],
         python_requires=">=3.6",
         entry_points={
             "spacy_tokenizers": [


### PR DESCRIPTION
Tests are green with explosion/spacy-stanza#101.  They fail because emoji 2.12.0 (a dependency of stanza) doesn't have a lower bound on typing-extensions (see carpedm20/emoji#297), but spacy has an upper bound ( :cry: ).

There are other ways to fix this¹ apart from dropping support for Python < 3.8, but with 3.7 being beyond its lifespan for almost 1 year and your work on spacy 4 (although I don't know when to expect this), I don't think its worth it.

Also: That the tests for Python 3.7 fail is unrelated to this PR.  They fail for the default branch as well.

¹Eg. relax the upper bound in spacy or disallow emoji 2.12.0 to be installed