### PR TITLE
Use stanza's sentence segmentation, add support for newer stanza versions and drop support for Python <3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,16 +21,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python_version: ["3.7", "3.11"]
+        python_version: ["3.8", "3.11"]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure Python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 spacy>=3.0.0,<4.0.0
-stanza>=1.2.0,<1.7.0
+stanza>=1.2.0, <2.0.0
 # Development dependencies
 pytest>=5.2.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def setup_package():
         license=about["__license__"],
         packages=find_packages(),
         install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0, <2.0.0"],
-        python_requires=">=3.6",
+        python_requires=">=3.8",
         entry_points={
             "spacy_tokenizers": [
                 "spacy_stanza.PipelineAsTokenizer.v1 = spacy_stanza:tokenizer.create_tokenizer",
@@ -43,8 +43,6 @@ def setup_package():
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
-            "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def setup_package():
         version=about["__version__"],
         license=about["__license__"],
         packages=find_packages(),
-        install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0,<1.7.0"],
+        install_requires=["spacy>=3.0.0,<4.0.0", "stanza>=1.2.0, <2.0.0"],
         python_requires=">=3.6",
         entry_points={
             "spacy_tokenizers": [

--- a/spacy_stanza/__init__.py
+++ b/spacy_stanza/__init__.py
@@ -10,7 +10,7 @@ def load_pipeline(
     lang: str = "",
     dir: Optional[str] = None,
     package: str = "default",
-    processors: Union[dict, str] = {},
+    processors: Union[dict, str] = None,
     logging_level: Optional[Union[int, str]] = None,
     verbose: Optional[bool] = None,
     use_gpu: bool = True,
@@ -32,6 +32,8 @@ def load_pipeline(
     **kwargs: Options for the individual stanza processors.
     RETURNS (Language): The nlp object.
     """
+    if processors is None:
+        processors = {}
     # Create an empty config skeleton
     config = {"nlp": {"tokenizer": {"kwargs": {}}}}
     if lang == "":


### PR DESCRIPTION
I have integrated most of the changes from #100, #101 and #102.
The changes: 

- add support for newer stanza versions (up to <2.0.0)
- drop support for older Python versions (3.6, 3.7)
- update the CI actions

In addition, I used the information from stanza's sentence segmentation to set `sent_starts` when initializing the space `Doc`. Previously, the `.sents` property was never set.