### PR TITLE
Remove upper bound on stanza

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 spacy>=3.0.0,<4.0.0
-stanza>=1.2.0,<1.7.0
+stanza>=1.2.0,<2.0.0
 # Development dependencies
 pytest>=5.2.0


### PR DESCRIPTION
Stanza is now on version 1.10.1.
Previous stanza versions have issues that cannot be addressed (e.g. https://github.com/stanfordnlp/stanza/issues/1429 which became a bug in torch 2.6.0). 

I haven't tested all the corner cases around the integration of spacy and stanza, but the package with torch 2.6.0 throws an error.

To reproduce, use the snippet from the readme:
```py
import stanza
import spacy_stanza

# Download the stanza model if necessary
stanza.download("en")

# Initialize the pipeline
nlp = spacy_stanza.load_pipeline("en")

doc = nlp("Barack Obama was born in Hawaii. He was elected president in 2008.")
for token in doc:
    print(token.text, token.lemma_, token.pos_, token.dep_, token.ent_type_)
print(doc.ents)
```

Output:
```
.../lib/python3.10/site-packages/torch/_weights_only_unpickler.py:529: UserWarning: Detected pickle protocol 3 in the checkpoint, which was not the default pickle protocol used by `torch.load` (2). The weights_only Unpickler might not support all instructions implemented by this protocol, please file an issue for adding support if you encounter this.